### PR TITLE
김진홍 38일차 문제 풀이

### DIFF
--- a/Study03 - Stack, Queue, Deque/Day38/kjh.kt
+++ b/Study03 - Stack, Queue, Deque/Day38/kjh.kt
@@ -1,0 +1,28 @@
+class Solution {
+    fun solution(bridgeLength: Int, weightLimit: Int, truckWeights: IntArray): Int {
+        val bridge = ArrayDeque<TruckInBridge>()
+        
+        var currentWeight = 0
+        for (truckWeight in truckWeights) {
+            val lastEnteredSec = (bridge.lastOrNull()?.enteredSec) ?: 0
+            if (currentWeight + truckWeight <= weightLimit) {
+                bridge.addLast(TruckInBridge(truckWeight, lastEnteredSec + 1))
+                currentWeight += truckWeight
+                continue
+            }
+            
+            var lastDequeued = TruckInBridge(0, 0)
+            while (currentWeight + truckWeight > weightLimit) {
+                lastDequeued = bridge.removeFirst()
+                currentWeight -= lastDequeued.weight
+            }
+            
+            bridge.addLast(TruckInBridge(truckWeight, Math.max(lastEnteredSec + 1, lastDequeued.enteredSec + bridgeLength)))
+            currentWeight += truckWeight
+        }
+        
+        return bridge.last().enteredSec + bridgeLength
+    }
+}
+
+data class TruckInBridge(val weight: Int, val enteredSec: Int)

--- a/Study03 - Stack, Queue, Deque/README.md
+++ b/Study03 - Stack, Queue, Deque/README.md
@@ -61,7 +61,7 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [다리를 지나는 트럭](https://school.programmers.co.kr/learn/courses/30/lessons/42583) | 진홍 수민 현수 희두 |
+| [다리를 지나는 트럭](https://school.programmers.co.kr/learn/courses/30/lessons/42583) | [진홍](Day38/kjh.kt) 수민 현수 희두 |
 
 ## [일차](Day)
 


### PR DESCRIPTION
## 로직

트럭들을 순회하며 아래를 수행한다

* 트럭을 다리에 올리면 제한하중이 초과된다면
    * 다리에 올릴 수 있을 때까지 dequeue하고
    * 마지막 dequeue된 것의 (들어간 초+다리의 길이)을 들어간 초로 enqueue함
        * 단, (들어간 초+다리의 길이)가 (peek의 들어간 초+1)보다 작으면 (peek의 들어간 초+1)을 들어간 초로 설정함

* 트럭을 올릴 수 있다면
    * (peek의 들어간 초+1)을 들어간 초로 enqueue함


순회가 끝난 뒤
* 모두 dequeue하고
* 마지막 dequeue된 것의 (들어간 초+다리의 길이)를 반환한다


## 복잡도

시간복잡도 O(N)
공간복잡도 O(N)

## 채점 결과

<img width="525" alt="image" src="https://user-images.githubusercontent.com/33937365/202847243-e52d5772-d75c-48c5-aa14-21826b18c6bc.png">
