### PR TITLE
유수민 41일차 문제 풀이 실패

### DIFF
--- a/Study03 - Stack, Queue, Deque/Day41/ysm.cpp
+++ b/Study03 - Stack, Queue, Deque/Day41/ysm.cpp
@@ -1,0 +1,44 @@
+#include <bits/stdc++.h>
+using namespace std;
+int n,i,j, flag;
+vector <string> ticketInfo;
+vector <string> sequence;
+stack <string> s;
+
+bool cmp(string &a, string &b){
+    string alpha = a.substr(0,1);
+    string alpha2 = b.substr(0,1);
+    int num1 = stoi(a.substr(2));
+    int num2 = stoi(b.substr(2));
+    if(alpha == alpha2) return num1 < num2;
+    return a < b;
+}
+
+int main(){
+    cin >> n;
+    for(int i = 0; i < n*5; i++){
+        string ticket;
+        cin >> ticket;
+        ticketInfo.push_back(ticket);
+    }
+    sequence = ticketInfo;
+    sort(sequence.begin(),sequence.end(),cmp);
+    
+    while(i < 5 * n && j < 5 * n){
+        if(ticketInfo[i] == sequence[j]) i++, j++;
+        else if(!s.empty() && s.top() == sequence[j]) s.pop(), j++;
+        else s.push(ticketInfo[i++]);
+    }
+
+    while(!s.empty()){
+        if(s.top()!=sequence[j++]){
+            flag = 1;
+            break;
+        }
+        s.pop();
+    }   
+
+    if(flag) cout << "BAD\n";
+    else cout << "GOOD\n";
+}
+

--- a/Study03 - Stack, Queue, Deque/README.md
+++ b/Study03 - Stack, Queue, Deque/README.md
@@ -79,7 +79,7 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [줄서기](https://www.acmicpc.net/problem/17178) | 진홍 수민 현수 희두 |
+| [줄서기](https://www.acmicpc.net/problem/17178) | 진홍 [수민](Day41/ysm.cpp) 현수 희두 |
 
 ## [일차](Day)
 


### PR DESCRIPTION
정렬된 배열과 기존의 배열과 비교하면서 결정해야 한다는 것을 놓쳤다 
## 로직
1. 입장 순서 정렬 - 알파벳이 앞쪽 일수록, 같다면 숫자가 작을수록 정렬
2. 기존 입력된 티켓과 정렬된 배열을 가장 왼쪽부터 비교한다. 
--  기존 입력된 티켓과 정렬딘 배열의 순서가 같다면 바로 입장 : 순서벡터에서 pop
-- 대기열이 채워져있고, 대기열의 top부분과 정렬된 배열 순서와 같을 경우 대기열에서 삭제하고  idx도 증가
-- 두의 경우 아니면 무조건 대기열에 넣는다. 
3. 대기열이 차있으면 정렬배열 순서와 비교하면서 만약 다르면 bad, 같으면 good이다. 
## 복잡도
시간복잡도 O(nlogN)
공간복잡도 O(N)


