### PR TITLE
김진홍 52일차 문제 풀이

### DIFF
--- a/Study05 - Recursion/Day52/kjh.kt
+++ b/Study05 - Recursion/Day52/kjh.kt
@@ -1,0 +1,38 @@
+import kotlin.math.*
+
+fun main() {
+    val (N, r, c) = readln().split(" ").map { it.toInt() }
+    
+    val sideLength = (2.0).pow(N).toInt()
+    print(solve(sideLength, r + 1, c + 1))
+}
+
+fun solve(sideLength: Int, r: Int, c: Int): Int {
+    val quadrant = getQuadrantNum(sideLength, r, c)
+    if (sideLength == 2) {
+        return quadrant - 1    
+    }
+    
+    val half = sideLength / 2
+    val area = sideLength * sideLength
+    when (quadrant) {
+        1 -> return solve(half, r, c)
+        2 -> return area / 4 * 1 + solve(half, r, c - half)
+        3 -> return area / 4 * 2 + solve(half, r - half, c)
+        else -> return area / 4 * 3 + solve(half, r - half, c - half)
+    }
+}
+
+fun getQuadrantNum(sideLength: Int, r: Int, c: Int): Int {
+    val standard = sideLength / 2
+    if (r <= standard && c <= standard) {
+        return 1
+    }
+    if (r <= standard && c > standard) {
+        return 2
+    }
+    if (r > standard && c <= standard) {
+        return 3
+    }
+    return 4
+}

--- a/Study05 - Recursion/README.md
+++ b/Study05 - Recursion/README.md
@@ -17,7 +17,7 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [Z](https://www.acmicpc.net/problem/1074) | 진홍 수민 현수 희두 |
+| [Z](https://www.acmicpc.net/problem/1074) | [진홍](Day52/kjh.kt) 수민 현수 희두 |
 
 ## [일차](Day)
 


### PR DESCRIPTION
## 로직

### 로직에 대한 직관적인 설명

N이 아닌 변의 길이를 기준으로 풀었습니다
(N=2라면 4x4의 칸이 생길 것이고 이때 변의 길이는 4)

재귀함수 func(변의 길이, r, c)에 대하여

![image](https://user-images.githubusercontent.com/33937365/205553912-5c7b4739-0d06-4137-b865-bf7d7e66c66e.png)

**2사분면일 경우**
func(변의 길이 / 2, r, c)를 반환합니다

변의 길이 / 2를 하는 이유는
'넓이가 4분의 1인 칸들에 대하여 r, c 좌표에 있는 값'과
'현 넓이에 대하여 r, c 좌표에 있는 값'이 같기 때문

**1사분면일 경우**
변의 길이 * 변의 길이 / 4 + func(변의 길이 / 2, r, c - 변의 길이 / 2)를 반환합니다

변의 길이 * 변의 길이 / 4를 더하는 이유는
1사분면일 경우 2사분면의 마지막 수+1부터 값이 시작할 것이기 때문

**3사분면일 경우**
변의 길이 * 변의 길이 / 4 * 2 + func(변의 길이 / 2, r - 변의 길이 / 2, c)를 반환합니다

변의 길이 * 변의 길이 / 4 * 2를 더하는 이유는
1사분면의 마지막 수+1부터 값이 시작할 것이기 때문

**4사분면일 경우**
변의 길이 * 변의 길이 / 4 * 2 + func(변의 길이 / 2, r - 변의 길이 / 2, c - 변의 길이 / 2)를 반환합니다

변의 길이 * 변의 길이 / 4 * 3를 더하는 이유는
3사분면의 마지막 수+1부터 값이 시작할 것이기 때문

ps.
코드에서는 편의상
2사분면을 1사분면으로,
1사분면을 2사분면으로 간주하였음

### 로직을 위와 같이 짠 계기&이유

2사분면 -> 1사분면 -> 3사분면 -> 4사분면
순으로 값이 커진다는 규칙을 발견하였음

이 규칙을 활용하여
좌표를 기준으로 몇 사분면에 속하는 지 알아보고
(해당 사분면의 시작값 + 해당 사분면 사각형에 대한 재귀 반환 값)을 재귀적으로 구하도록 하여
가장 작은 사각형인 2*2가 재귀호출의 기저사례가 되어 0, 1, 2, 3을 반환해주면
답을 구할 수 있을 거라는 결론을 얻어서 위와 같이 짰음

## 복잡도

시간복잡도 O(N)
공간복잡도 O(N)

2^N에서부터, 나누기 2를 해가면서, 2^1이 될때까지 재귀호출을 하므로
시간 복잡도를 O(N)으로 산정했습니다

N에 비례해서 재귀호출을 하므로 그만큼 쌓일 콜스택을 고려해
공간복잡도를 O(N)으로 산정헀습니다

## 채점 결과

<img width="1188" alt="CleanShot 2022-12-05 at 14 07 01@2x" src="https://user-images.githubusercontent.com/33937365/205553834-5429e029-f17b-4799-9beb-ba904dcb67e5.png">