### PR TITLE
김진홍 59일차 문제 풀이

### DIFF
--- a/Study06 - Exhaustive Search/Day59/kjh.kt
+++ b/Study06 - Exhaustive Search/Day59/kjh.kt
@@ -1,0 +1,29 @@
+fun main() {
+    val dwarfs = ArrayList<Int>()
+    
+    repeat(9) {
+        val height = readln().toInt()
+        dwarfs.add(height)
+    }
+    
+    dwarfs.exceptFake()
+    dwarfs.sort()
+
+    print(dwarfs.joinToString("\n"))
+}
+
+fun ArrayList<Int>.exceptFake() {
+    for (i in 0..8) {
+        for (j in (i+1)..8) {
+            val heightA = this[i]
+            val heightB = this[j]
+            
+            val isFake = (this.sum() - heightA - heightB) == 100
+            if (isFake) {
+                this.removeAt(i)
+                this.removeAt(j-1)
+                return
+            }
+        }
+    }
+}

--- a/Study06 - Exhaustive Search/README.md
+++ b/Study06 - Exhaustive Search/README.md
@@ -5,7 +5,7 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [완전탐색](https://www.acmicpc.net/problem/2309) | 진홍 수민 현수 희두 |
+| [완전탐색](https://www.acmicpc.net/problem/2309) | [진홍](Day59/kjh.kt) 수민 현수 희두 |
 
 ## [일차](Day)
 


### PR DESCRIPTION
## 로직

### 사용한 자료구조와 이유

리스트, 드워프의 신장을 담기 위해

### 로직에 대한 직관적인 설명

1. 두 드워프를 뽑는 모든 경우의 수를 모두 탐색하며
2. 전체 합에서 두 드워프를 키를 뺐을때 100이 되는 두 드워프를 찾아서 제외한다.
3. 나머지 진짜 드워프들의 키를 정렬해서 출력한다.

### 로직을 위와 같이 짠 계기&이유

입력이 굉장히 작아서 완전탐색을 적용하기 안성맞춤

## 복잡도

시간복잡도 O(N^3) 
* 드워프 N에 대하여 2중 중첩 for문을 사용하고
  * 그 안에서 또 전체 합을 구하는 O(N)의 sum 함수를 사용하기 때문에

공간복잡도 O(N) : N이 9로 너무 작아서 1로 쳐도 될듯

## 채점 결과

<img width="1181" alt="CleanShot 2022-12-12 at 23 22 50@2x" src="https://user-images.githubusercontent.com/33937365/207069330-0a5de171-5e5a-4c93-bf38-1c07aafb4a97.png">