### PR TITLE
유수민 76일차 문제 재풀이

### DIFF
--- a/Study08 - Dynamic Programming/Day76/ysm2.cpp
+++ b/Study08 - Dynamic Programming/Day76/ysm2.cpp
@@ -1,0 +1,30 @@
+#include<iostream>
+#include<vector>
+#include<algorithm>
+using namespace std;
+
+int n;
+int wine[10001];
+int dp[10001];
+int check() {
+	
+	dp[1] = wine[1];
+	dp[2] = wine[1] + wine[2];
+
+	for (int x = 3; x <= n; x++) {
+		dp[x] = max(dp[x - 3] + wine[x - 1] + wine[x], max(dp[x - 2] + wine[x], dp[x - 1]));
+	}
+
+	return dp[n];
+}
+int main() {
+	
+	cin >> n;
+	for (int x = 1; x <= n; x++) {
+		cin >> wine[x];
+
+	}
+
+	cout << check();
+	return 0;
+}


### PR DESCRIPTION
## 로직
확실히 전날에 풀었던 문제라 규칙 찾기가 좀 더 쉬웠다. 이번에는 와인을 먹고 안먹고를 ox를 그리면서 점화식을 구했다. 
- dp배열이 전역으로 선언되었기 때문에 dp[0] = 0은 해줄 필요가 없다. 
- max 안에 max를 한것은 3개중 최대를 구할 수 없으니 2개중 최대값과 나머지 한값의 최대를 구하기 위함이다. 
- dp배열의 표현을 어떻게 하느냐가 젤 어렵다. 
### 로직에 대한 직관적인 설명
이 문제에서 dp는 최대로 먹을 수 있는 와인의 수로 정의하였다. 어제 말한 경우의 수가 3가지가 있는데
1. i-3번째를 마시고 i-1,i번째를 마신다.
2. i-2번째를 마시고 i번째를 마신다.
3. i-1번째를 마시고 i번째를 마시지 않는다.

이렇게 말하기 보단

1. i-3번째까지 최대로 먹고 i-1잔과 i잔을 마신다
2. i-2번째까지 최대로 먹고 i잔을 마신다. 
3. i-1번째까지 최대로 먹고 i잔을 안마신다
로 표현을 변경하니 더 이해가 잘되었다. 

### 로직을 위와 같이 짠 계기&이유
3가지 경우의 수를 짜서 코드로 표현하니 dp 점화식이 나왔다. 

## 복잡도

시간복잡도 O(N) -> for문
공간복잡도 O(1)

## 채점 결과
![image](https://user-images.githubusercontent.com/68679529/210100302-59376929-322b-4984-94a2-1aa1b8679512.png)

