### PR TITLE
한현수 89일차 문제 풀이

### DIFF
--- a/Study10 - Graph And DFS/Day89/hhs.java
+++ b/Study10 - Graph And DFS/Day89/hhs.java
@@ -1,0 +1,61 @@
+package BOJ_13023;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+    static int N, M, answer = 0;
+    static int count;
+    static boolean[] visited;
+    static List<List<Integer>> graph = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i < N; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            graph.get(a).add(b);
+            graph.get(b).add(a);
+        }
+
+        visited = new boolean[N];
+
+        for (int i = 0; i < N; i++) {
+            count = 0;
+            dfs(i, count);
+            if (answer == 1) {
+                break;
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    public static void dfs(int node, int count) {
+        visited[node] = true;
+        if (count >= 4) {
+            answer = 1;
+            return;
+        }
+
+        for (int nextNode : graph.get(node)) {
+            if (!visited[nextNode]) {
+                dfs(nextNode, count + 1);
+            }
+        }
+        visited[node] = false;
+    }
+}

--- a/Study10 - Graph And DFS/README.md
+++ b/Study10 - Graph And DFS/README.md
@@ -29,7 +29,7 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [ABCDE](https://www.acmicpc.net/problem/13023) | 진홍 수민 현수 지우 |
+| [ABCDE](https://www.acmicpc.net/problem/13023) | 진홍 수민 [현수](Day89/hhs.java) 지우 |
 
 # 회고 내용
 


### PR DESCRIPTION
## 로직

### 로직에 대한 직관적인 설명

입력받은 정보들을 토대로 인접 리스트를 만들어 그래프를 구성한다.(N의 범위가 작아서 인접 행렬도 가능할 것 같다.)

dfs를 수행하되 depth가 5라면 함수를 종료하고(더이상 볼 필요가 없다. 5명의 친구가 이어져있다는 것을 알았기 때문에.) 1을 출력한다.

그리고 주의해야할 점이 dfs를 마치면 해당 노드를 다시 방문했다는 표시를 미방문으로 바꾼다. 즉 백트래킹을 하는 것

모든 노드를 순회해도 depth가 5가 넘지 않는다면 0을 출력한다.

### 로직 도출 과정

문제를 보고나서 depth의 길이를 판단하면 된다고 생각했고 또한 dfs를 처음으로 수행한 노드마다 결과가 다르기 때문에 매번 방문 배열을 초기화 해야한다고 생각했다.

나는 방문 배열 초기화 위치를 dfs함수 내부가 아니라 외부로 지정했는데 46퍼센트에서 틀리다고 나왔다. 왜그런지 좀만 생각해봤는데 이유는 간단했다.

#### 예시

1번 노드부터 시작하는 dfs를 수행한 후 방문 배열 초기화: 1-2-3-4-5 <- 한개의 답만 나온다.

1번 노드부터 시작하는 dfs를 수행(중간에 방문 했던 노드를 다시 미방문으로, 백트래킹): 1-2-3-4-5, 1-3-2-4-5, 1-5-2-3-4 <- 여러가지 답을 구할 수 있다.

즉 우리는 여러가지 길을 판단해서 depth가 5가 넘는지 봐야한다. 그래서 백트래킹을 이용해야한다.

## 복잡도

시간복잡도 - O(N + M): 최악의 경우는 모든 노드, 간선을 확인하는 것이다.
공간복잡도 - O(N + M): N개의 정점, M개의 간선(인접리스트)

## 채점 결과

<img width="1157" alt="스크린샷 2023-01-16 오전 2 22 07" src="https://user-images.githubusercontent.com/37373826/212556641-1155d991-be55-4355-b5de-8699e969d3e0.png">

### Review 양식 (참고)
> 1. 로직 설명이 이해되는 정도를 세 가지 중 하나 골라서 평가해주기 (필수)
> * 직관적이고 아주 잘 이해된다.
> * 대체적으로 잘 이해되는 편이나, 구체적이어서 직관성이 조금 떨어지는 부분이 있다.
> * 대체적으로 잘 이해되는 편이나, 추상적이어서 설명을 이해하기 어려운 부분이 있다.
> 2. 이런 점이 좋았다 (선택)
> 3. 이런 점이 보완되면 더 좋겠다 (선택)
