### PR TITLE
김진홍 95일차 문제 풀이

### DIFF
--- a/Study11 - Graph And BFS/Day95/kjh.kt
+++ b/Study11 - Graph And BFS/Day95/kjh.kt
@@ -1,0 +1,53 @@
+import java.util.*
+
+val dy = arrayOf(-1, 1, 0, 0)
+val dx = arrayOf(0, 0, -1, 1)
+val dd = arrayOf(Direction.UP_DOWN, Direction.UP_DOWN, Direction.LEFT_RIGHT, Direction.LEFT_RIGHT)
+
+class Solution {
+    fun solution(board: Array<IntArray>): Int {
+        val minCost = Array(board.size) { Array(board.size) { IntArray(3) { Int.MAX_VALUE } } }
+        
+        val queue: Queue<Node> = LinkedList<Node>()
+        queue.offer(Node(0, 0, Direction.NONE))
+        minCost[0][0][0] = 0
+        minCost[0][0][1] = 0
+        minCost[0][0][2] = 0
+        
+        while (queue.size > 0) {
+            val (y, x, direction) = queue.poll()
+            
+            for (i in 0..3) {
+                val nextY = dy[i] + y
+                val nextX = dx[i] + x
+                
+                val outOfIndex = nextY < 0 || nextX < 0 || nextY >= board.size || nextX >= board.size
+                if (outOfIndex) continue
+                if (board[nextY][nextX] == 1) continue
+                
+                val nextDirection = dd[i]
+                val nextCost = minCost[y][x][direction.code] + 100 + if (direction.isCorner(nextDirection)) 500 else 0
+                
+                if (nextCost < minCost[nextY][nextX][nextDirection.code]) {
+                    minCost[nextY][nextX][nextDirection.code] = nextCost
+                    queue.add(Node(nextY, nextX, nextDirection))
+                }
+            }
+        }
+        
+        return minCost[board.size-1][board.size-1].minOrNull()!!
+    }
+}
+
+data class Node(val y: Int, val x: Int, val direction: Direction)
+
+enum class Direction(val code: Int) {
+    LEFT_RIGHT(1),
+    UP_DOWN(2),
+    NONE(0);
+    
+    fun isCorner(nextDirection: Direction): Boolean {
+        return (this == Direction.LEFT_RIGHT && nextDirection == Direction.UP_DOWN)
+            || (this == Direction.UP_DOWN && nextDirection == Direction.LEFT_RIGHT)
+    }
+}

--- a/Study11 - Graph And BFS/README.md
+++ b/Study11 - Graph And BFS/README.md
@@ -35,4 +35,4 @@
 
 | 문제                 | 답안                |
 | -------------------- | ------------------- |
-| [경주로 건설](https://school.programmers.co.kr/learn/courses/30/lessons/67259) | 진홍 수민 현수 지우 |
+| [경주로 건설](https://school.programmers.co.kr/learn/courses/30/lessons/67259) | [진홍](Day95/kjh.kt) 수민 현수 지우 |


### PR DESCRIPTION
## 로직

### 로직에 대한 직관적인 설명

minCost 3차원 배열을 둔다
`minCost[y][x][d] = c`
위와 같이 있다면
(y, x)좌표에 마지막 건설 방향이 d일때의 최소 비용은 c라는 의미다

방향 d는 무방향=0, 좌우=1, 상하=2 중 하나다.

minCost[0][0][0], minCost[0][0][1], minCost[0][0][2]만 0으로 초기화해두고
나머지는 2147483647(Int.MAX_VALUE)로 초기화시켜둔다

큐에 Node(y: 0, x: 0, d: 0)을 추가한다. (다음에 어느 방향으로 건설되든 코너로 인식되지 않기 위해 무방향(d: 0)으로 추가해야 한다.)

큐가 빌때까지 아래를 반복한다
* 상하좌우 4블록 중, 도로를 지을 수 있고 해당 위치에 도로를 지었을때 minCost[y][x][d] 값을 갱신할 수 있는 블록에 대해서만
* minCost 값을 갱신하고 해당 블록 Node를 추가한다.

큐가 비면 minCost[N-1][N-1][0], minCost[N-1][N-1][1], minCost[N-1][N-1][2] 중 최소값을 반환한다

### 로직 도출 과정

이 역시 BFS로 풀면 될 것 같아서 일단 BFS로 풀어봤다.
틀렸다고 나왔다.

확인해보니 "이전에 어느 방향에서 왔는지"가 최소 비용에 영향을 끼쳐서 그런 것이였다!

예를 들어 (2, 2) 블록이 있고, 최소비용으로 도로를 만들기 위해서는 아래로만({3,2} {4,2} {5,2}...) 지어야한다고 하자.

그러면 (2,1)->(2,2)로 와서 비용이 총 1000인 것보다
(1,2)->(2,2)로 와서 비용이 1300인 게 더 유리하다.

왜냐면 다음 블록은 (3,2)로 정해져있는데
(2,1)->(2,2)->(3,2)는 코너를 만들어서 다음 도로 건설 비용이 600이 들어 1600이 되는데 반해
(1,2)->(2,2)->(3,2)는 직선도로여서 다음 도로 건설 비용이 100이 들어 총 1400밖에 안되기 때문이다.

그래서 최소비용을 계산할때 '방향'도 같이 고려해야했다.

minCost 배열에 1차원을 추가해서 방향으로 써먹었더니 풀렸다.

## 복잡도

시간복잡도 O(N^2) : 최악의 경우 모든 노드를 2번씩 방문하므로
공간복잡도 O(N^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

## 채점 결과

<img width="874" alt="image" src="https://user-images.githubusercontent.com/33937365/214500314-5c1c6f78-872a-453e-921c-98a8a4ee7f1a.png">


### Review 양식 (참고)
> 1. 로직 설명이 이해되는 정도를 세 가지 중 하나 골라서 평가해주기 (필수)
> * 직관적이고 아주 잘 이해된다.
> * 대체적으로 잘 이해되는 편이나, 구체적이어서 직관성이 조금 떨어지는 부분이 있다.
> * 대체적으로 잘 이해되는 편이나, 추상적이어서 설명을 이해하기 어려운 부분이 있다.
> 2. 이런 점이 좋았다 (선택)
> 3. 이런 점이 보완되면 더 좋겠다 (선택)
