### PR TITLE
유수민 111일차 문제 풀이 실패

### DIFF
--- a/Study14 - Shortest path/Day111/ysmC.cpp
+++ b/Study14 - Shortest path/Day111/ysmC.cpp
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <iostream>
+#include <vector>
+#include <queue>
+using namespace std;
+ 
+vector<pair<int, int>> graph[20010];
+int d[20010];
+int V, E, start;
+ 
+void dijkstra(int start)
+{
+    priority_queue<pair<int, int>, vector<pair<int, int>>, greater<pair<int, int>>> pq;
+    pq.push({0, start});
+    d[start] = 0;
+    
+    while(!pq.empty())
+    {
+        int now = pq.top().second;
+        int nowCost = pq.top().first;
+        pq.pop();
+        
+        if(nowCost != d[now])
+        {
+            continue;    
+        }
+        
+        for(int i = 0; i < graph[now].size(); i++)
+        {
+            int next = graph[now][i].first;
+            int nextCost = graph[now][i].second;
+            
+            if(nowCost+nextCost < d[next])
+            {
+                d[next] = nowCost+nextCost;
+                pq.push({d[next], next});
+            }
+        }
+    }
+}
+ 
+int main(void)
+{
+
+    
+    cin >> V >> E >> start;
+    
+    for(int i = 1; i <= V; i++)
+    {
+        d[i] = 9999999;
+    }
+ 
+    for(int i = 1; i <= E; i++)
+    {
+        int from, to, weight;
+        cin >> from >> to >> weight;
+        
+        graph[from].push_back({to, weight});
+    }
+    
+    dijkstra(start);
+    
+    for(int i = 1; i <= V; i++)
+    {
+        if(d[i] == 9999999)
+        {
+            cout << "INF" << "\n";    
+        }
+        else
+        {
+            cout << d[i] << "\n";        
+        }
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
## 로직
최단 경로를 안풀어봤었어서 처음에는 단순히 bfs 이용해서 풀려고 했는데 안풀려져서 답을 확인했다. 
1. 간선에 가중치가 존재한다면 BFS를 사용할 수 없다.(가중치가 0과 1만 존재하는 그래프에서는 BFS를 쓴다). 가중치가 있을 경우 다익스트라 알고리즘를 사용한다.
2. 우선순위큐를 사용한다.
3. 시작점에서 다른 모든 정점으로의 최단거리를 저장할 배열을 사용한다. 

### 로직에 대한 직관적인 설명
1. 시작점에서 다른 모든 정점으로의 최단거리를 저장할 배열 d를 선언
2. 간선을 인접리스트형태로 저장하기 위해 vector 배열 graph을 선언한다. 정점 번호와 가중치를 함께 저장해야 하기 때문에 pair를 사용한다.
3. 입력받은 간선을 graph에 추가합니다. 아래에서 priority queue를 사용하여 min heap을 만들 때 가중치를 기준으로 정렬해야 하므로 가중치(w), 정점 번호(v)순으로 pair를 만들어서 추가한다.
4.시작점에서 시작점으로의 거리는 문제에서 제시한대로 0으로 바꿔준다
5. priority_queue를 선언합니다. priority_queue<자료형, 구현체, 비교 연산자>의 형태로 사용해야 하므로 구현체는 기본값인 vector를 사용했고, 비교 연산자는 greater를 사용하여 min heap을 만든다.
6. pq에 시작점을 추가합니다.
7. 가중치가 가장 작은 간선을 꺼내서 next에 가중치를, nextCost에 정점을 저장합니다.
8. 현재 저장되어 있는 최단 거리(d[next])보다 nowCost+nextCost한 값이 작으면
9. (d[next])에 nowCost+nextCost를 저장하여 최단 거리를 갱신하고, pq에 추가합니다.
10.1번 정점부터 V번 정점까지 돌면서 경로가 존재하지 않는 경우에는 INF를 출력하고, 시작점부터 i번째 점까지의 최단 거리를 출력합니다.


## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도와 공간복잡도 작성 -->

시간복잡도 O((V+E)*logV) : 시작 노드의 인접 노드는 최대 v개이므로, 처음 우선순위 큐를 완성하는 시간 O(v∗logv)에, 존재하는 모든 간선 정보를 큐에 삽입한다 해도 최대 O(e∗logn)의 시간 복잡도를 가지므로 최악의 경우 O((v+e)∗logv)의 시간 복잡도
공간복잡도 O(VE) : 인접리스트

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 



### Review 양식 (참고)
> 1. 로직 설명이 이해되는 정도를 피드백해주기 (필수)
```⭐️x10 완벽해요!```
> 2. 이런 점이 좋았다 (선택)
> 3. 이런 점이 보완되면 더 좋겠다 (선택)
